### PR TITLE
Make sure the filePath is last in the args

### DIFF
--- a/src/pg-restore.ts
+++ b/src/pg-restore.ts
@@ -91,8 +91,7 @@ export const pgRestore = async (
   if (!filePath) throw new Error('Needs filePath in the options')
 
   const args: string[] = getConnectionArgs(connectionOptions)
-
-  args.push(filePath)
+  
   if (format) args.push(`--format=${format}`)
   if (fileName) args.push(`--filename=${fileName}`)
   if (index) args.push(`--index=${index}`)
@@ -138,6 +137,8 @@ export const pgRestore = async (
   Object.keys(paramsMap).forEach((key) => {
     if (paramsMap[key]) args.push(`--${key}`)
   })
+  
+  args.push(filePath)
 
   return execa('pg_restore', args, {})
 }


### PR DESCRIPTION
To prevent the error "Too many command-line arguments for pg_restore"

Per Postgres Doc: Usage: pg_restore [OPTION]... [FILE]