### PR TITLE
extends the ability to exclude more patterns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pg-dump-restore",
-  "version": "1.0.6",
+  "version": "1.0.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pg-dump-restore",
-      "version": "1.0.6",
+      "version": "1.0.8",
       "license": "ISC",
       "dependencies": {
         "execa": "^5.1.1"

--- a/readme.md
+++ b/readme.md
@@ -44,3 +44,27 @@ async function main() {
   ); // outputs an execa object
 }
 ```
+### Command excludeTableDataPattern
+
+The `excludeTableDataPattern` command allows excluding data from one or more tables during an operation. It can receive an array of names or patterns to specify the tables to be excluded. This option is useful when you only need the definition of a particular table but do not require the data it contains.
+
+```typescript
+import { pgDump, pgRestore } from "pg-dump-restore";
+
+async function main() {
+  const { stdout, stderr } = await pgDump(
+    {
+      port, // defaults to 5432
+      host,
+      database,
+      username,
+      password,
+    },
+    {
+      file: "./dump.sql",
+      format, // defaults to 'custom'
+      excludeTableDataPattern: ["table1", "table2"]
+    },
+  ); // outputs an execa object
+}
+```

--- a/src/pg-dump.ts
+++ b/src/pg-dump.ts
@@ -17,7 +17,7 @@ export type DumpOptionsType = {
   excludeSchemaPattern?: string
   tablePattern?: string
   excludeTablePattern?: string
-  excludeTableDataPattern?: string
+  excludeTableDataPattern?: string[]
   noOwner?: boolean
   noReconnect?: boolean
   schemaOnly?: boolean
@@ -128,7 +128,9 @@ export const pgDump = async (
   if (tablePattern) args.push(`--table=${tablePattern}`)
   if (excludeTablePattern) args.push(`--exclude-table=${excludeTablePattern}`)
   if (compress !== undefined) args.push(`--compress=${compress}`)
-  if (excludeTableDataPattern) args.push(`--exclude-table-data=${excludeTableDataPattern}`)
+  if (excludeTableDataPattern && Array.isArray(excludeTableDataPattern) && excludeTableDataPattern.length !== 0) {
+    args.push(...excludeTableDataPattern.map(tableData => `--exclude-table-data=${tableData}`))
+  }
   if (extraFloatDigits !== undefined) args.push(`--extra-float-digits=${extraFloatDigits}`)
   if (includeForeignData) args.push(`--include-foreign-data=${includeForeignData}`)
   if (lockWaitTimeout) args.push(`--lock-wait-timeout=${lockWaitTimeout}`)

--- a/src/pg-dump.ts
+++ b/src/pg-dump.ts
@@ -89,7 +89,7 @@ export const pgDump = async (
     disableDollarQuoting,
     disableTriggers,
     enableRowSecurity,
-    excludeTableDataPattern,
+    excludeTableDataPattern = [],
     extraFloatDigits,
     ifExists,
     includeForeignData,
@@ -128,9 +128,7 @@ export const pgDump = async (
   if (tablePattern) args.push(`--table=${tablePattern}`)
   if (excludeTablePattern) args.push(`--exclude-table=${excludeTablePattern}`)
   if (compress !== undefined) args.push(`--compress=${compress}`)
-  if (excludeTableDataPattern && Array.isArray(excludeTableDataPattern) && excludeTableDataPattern.length !== 0) {
-    args.push(...excludeTableDataPattern.map(tableData => `--exclude-table-data=${tableData}`))
-  }
+  args.push(...excludeTableDataPattern.map(item => `--exclude-table-data=${item}`))
   if (extraFloatDigits !== undefined) args.push(`--extra-float-digits=${extraFloatDigits}`)
   if (includeForeignData) args.push(`--include-foreign-data=${includeForeignData}`)
   if (lockWaitTimeout) args.push(`--lock-wait-timeout=${lockWaitTimeout}`)


### PR DESCRIPTION
extends the ability to exclude more than one pattern or database table from a backup. This command can be repeated as many times as patterns or entities we want to exclude from the dump